### PR TITLE
minor fix to enable float step value

### DIFF
--- a/frontend/Index.svelte
+++ b/frontend/Index.svelte
@@ -41,14 +41,14 @@
     }
   
     function handle_min_change(event) {
-      selected_min = parseInt(event.target.value);
+      selected_min = parseFloat(event.target.value);
       if (selected_min > selected_max) {
         selected_max = selected_min;
       }
     }
   
     function handle_max_change(event) {
-      selected_max = parseInt(event.target.value);
+      selected_max = parseFloat(event.target.value);
       if (selected_max < selected_min) {
         selected_min = selected_max;
       }


### PR DESCRIPTION
The 'handle_min_change' and 'handle_max_change' currently parse values to integers preventing the use of float step values (eg step=0.1).

The proposed suggestion enables to have float min/max values such that the step argument acts as in the original Slider gradio component.